### PR TITLE
Automatically split into full sentences less than 5000 characters or less. Multiple downloads from text greater than 5000 characters.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vscode
 /node_modules
 /.cache
+src/.vscode/launch.json

--- a/src/typescript/wavenet.ts
+++ b/src/typescript/wavenet.ts
@@ -11,7 +11,45 @@ export default class WaveNet {
     chrome.storage.sync.get(null, async (settings) => {
       if (!this.validateSettings(settings)) return
 
-      let audioContent = await this.getAudioContent(settings, input, 'MP3')
+      if(input.length > 4999){
+        var curparagraph = ""
+        var paragraphs = []
+        var paralen
+        //Taken shamelessly from https://www.sitepoint.com/community/t/choose-whole-sentences-and-only-whole-sentences-reliably-with-regex/8075/4
+        var regex1 = new RegExp(/["’]?[A-Z][^.?!]+((?![.?!][’"]?\s["’]?[A-Z][^.?!]).)+[.?!’"]+/g)
+        var allsentences
+        
+        allsentences = regex1.exec(input)
+        paralen = curparagraph.length + allsentences[0].length
+        while (allsentences) {
+          while (paralen < 4999) {
+            curparagraph = curparagraph + " " + allsentences[0]
+            allsentences = regex1.exec(input);
+            if (allsentences != null) {
+              paralen = curparagraph.length + allsentences[0].length;
+            }
+            else {
+              break
+            }
+          }
+          paragraphs.push(curparagraph)
+          paralen = 0
+          curparagraph = ""
+        }       
+
+      } else {
+        curparagraph = input
+      }
+
+      this.getDownloads(paragraphs, settings)
+    })
+  }
+
+  public async getDownloads(paras, settings)
+  {
+    paras.forEach(async paragraph => {
+
+      let audioContent = await this.getAudioContent(settings, paragraph, 'MP3')
       if (audioContent === null) return
 
       const blob = await (await fetch(`data:audio/mp3;base64,${audioContent}`)).blob()

--- a/src/typescript/wavenet.ts
+++ b/src/typescript/wavenet.ts
@@ -10,10 +10,11 @@ export default class WaveNet {
   public download(input: string) {
     chrome.storage.sync.get(null, async (settings) => {
       if (!this.validateSettings(settings)) return
-
+      
+      var paragraphs = []
+      
       if(input.length > 4999){
         var curparagraph = ""
-        var paragraphs = []
         var paralen
         //Taken shamelessly from https://www.sitepoint.com/community/t/choose-whole-sentences-and-only-whole-sentences-reliably-with-regex/8075/4
         var regex1 = new RegExp(/["’]?[A-Z][^.?!]+((?![.?!][’"]?\s["’]?[A-Z][^.?!]).)+[.?!’"]+/g)
@@ -38,7 +39,7 @@ export default class WaveNet {
         }       
 
       } else {
-        curparagraph = input
+        paragraphs.push(input)
       }
 
       this.getDownloads(paragraphs, settings)
@@ -47,17 +48,23 @@ export default class WaveNet {
 
   public async getDownloads(paras, settings)
   {
-    paras.forEach(async paragraph => {
-
+    var i = 0
+    for (const paragraph of paras) {
       let audioContent = await this.getAudioContent(settings, paragraph, 'MP3')
       if (audioContent === null) return
+      const digitnumber = ("00" + i).substr(-3,3);
 
-      const blob = await (await fetch(`data:audio/mp3;base64,${audioContent}`)).blob()
-      chrome.downloads.download({
-        url: URL.createObjectURL(blob),
-        filename: `download.mp3`
+      fetch(`data:audio/mp3;base64,${audioContent}`)
+        .then(response => response.blob())
+        .then(function (myBlob) {
+          chrome.downloads.download({
+            url: URL.createObjectURL(myBlob),
+            filename: "download" + digitnumber + ".mp3"
+        })
       })
-    })
+
+      i++
+    };    
   }
 
   public async start(input: string) {


### PR DESCRIPTION
Using the discussion at https://www.sitepoint.com/community/t/choose-whole-sentences-and-only-whole-sentences-reliably-with-regex/8075/4 as a starting point, create an array of paragraphs, each less than 5000 characters, but only full sentences.
Pass this list to the download function. Will return multiple .mp3 files, not necessarily in order of the text (TODO).

(First time writing TypeScript, so be gentle on style please. :)